### PR TITLE
feat(org.id-profile-manager): added useKey react hook

### DIFF
--- a/packages/dapp/docs/useKey.md
+++ b/packages/dapp/docs/useKey.md
@@ -1,0 +1,15 @@
+# useKey react hook
+
+Registered keys API is a React hook useKey. This hook accepts a keyId or tag as an input parameter and returns [key, signer, error] as hook parameters:
+- `key` is a dynamic property with a key record
+- `signer` is an `ethers.js` `signer` (can be obtained using provider.getSigner) for a selected key. If key is not currently selected in the Wallet this property must be `undefined`
+- `isConnected` is a dynamic property key connection status
+- `error` is a dynamic property that refers to internal hook errors, the default value is `undefined`
+
+### Usage in a component:
+
+```typescript
+export const myComponent = () => {
+  const[key, signer, isConnected, error] = useKey(keyIdOrTag);
+};
+```

--- a/packages/dapp/docs/useKeysManager.md
+++ b/packages/dapp/docs/useKeysManager.md
@@ -1,0 +1,30 @@
+# useKeysManager react hook
+
+- Keys management API is a React hook `useKeysManager`. This hook returns `[keys, add, update, remove, revoke, loading, error]` as hook parameters:
+    - `addKey(record: KeyRecord)` is an async function that allows registering keys
+    - `updateKey(record: KeyRecord)` is an async function that allows updating existing key
+    - `removeKey(tag: string)` is an async function that allows removing existing keys
+    - `revokeKey(tag: string, reason: string)` is an async function that allows revoking existing keys
+    - `loading` is a dynamic boolean value that indicates that the registered keys list is reloading
+    - `error` is a dynamic property that refers to internal hook errors, the default value is `undefined`
+
+### Usage in a component:
+
+```typescript
+export const myComponent = () => {
+  const [
+    addKey,
+    updateKey,
+    removeKey,
+    revokeKey,
+    loading,
+    error
+  ] = useKeysManager();
+
+  return (
+    <Button onClick=() => addKey(RawKeyRecord)>
+      Add key
+    </Button>
+  );
+};
+```

--- a/packages/dapp/src/components/KeyFormModal.tsx
+++ b/packages/dapp/src/components/KeyFormModal.tsx
@@ -1,0 +1,166 @@
+import type { AnySchema } from '@windingtree/org.id-utils/dist/object';
+import { useState, FC, useEffect, useCallback, useContext } from 'react';
+import { Box, Button, Form, FormField, TextInput, Text, ResponsiveContext } from 'grommet';
+import { MessageBox } from './MessageBox';
+import { useKeysManager, allowedKeysTypes, revocationReasonValues } from '../hooks/useKeysManager';
+import { useAppState } from '../store';
+import { KeyRecordRaw } from '../store/actions';
+import { Modal } from './Modal';
+import { object } from '@windingtree/org.id-utils';
+import { useRequestPermissions } from '../hooks/useRequestPermissions';
+
+export const keyRecordRawSchema: AnySchema = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string',
+      enum: allowedKeysTypes
+    },
+    publicKey: {
+      type: 'string'
+    },
+    tag: {
+      type: 'string'
+    },
+    note: {
+      type: 'string'
+    },
+    revocation: {
+      type: 'object',
+      properties:{
+        reason: {
+          type: 'string',
+          enum: revocationReasonValues
+        },
+        invalidityDate: {
+          type: 'string',
+          format: 'date-time'
+        },
+      },
+      required: ['reason', 'invalidityDate']
+    }
+  },
+  required: ['type', 'publicKey', 'tag']
+}
+
+const validateKeyRecordRawWithSchema = (record: KeyRecordRaw): string | null =>
+  object.validateWithSchemaOrRef(
+    keyRecordRawSchema,
+    '',
+    record
+  );
+
+const defaultRecord:KeyRecordRaw = {
+  tag: '',
+  publicKey:'',
+  note:'',
+  type: allowedKeysTypes[0]
+}
+
+export const KeyFormModal:FC<{show: boolean;close():void}> = ({show, close, children}) => {
+  const size = useContext(ResponsiveContext);
+  const { account, keys, provider } = useAppState();
+  const [addKey,,,,,keyError] = useKeysManager();
+  const [rawRecord, setRawRecord] = useState(defaultRecord);
+  const [requestPermissions] = useRequestPermissions(provider);
+
+  const [processing, setProcessing] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    setError(keyError);
+  }, [keyError]);
+
+  useEffect(() => {
+    setProcessing(false);
+  }, [keyError, error]);
+
+  const onSubmit = useCallback(async (value:KeyRecordRaw) => {
+    setProcessing(true)
+    try {
+      value = {
+        ...value,
+        publicKey: account
+      };
+      const validationResult = validateKeyRecordRawWithSchema(value);
+      if (validationResult !== null) {
+        throw new Error(`Validation error: ${validationResult}`);
+      }
+
+      const id = await addKey(value)
+      if (id !== undefined) {
+        close()
+        setRawRecord({...defaultRecord})
+      }
+
+    } catch(error) {
+      setProcessing(false);
+      setError((error as Error).message || 'Unknown error');
+    }
+
+  },[account, setError, addKey, setProcessing, close]);
+
+  return (
+    <Modal show={show} onClose={close}>
+      <Box pad='large' >
+        <Form
+          value={rawRecord}
+          validate='blur'
+          onChange={nextValue => setRawRecord(nextValue)}
+          onReset={() => {
+            setError(undefined);
+            setRawRecord({...defaultRecord})
+            close()
+          }}
+          onSubmit={({ value }) => onSubmit(value)}
+        >
+          <Box border='bottom' direction='row' pad='small' justify='between' height='xsmall'>
+            <Box direction='column' justify='between' >
+              <Text>Account</Text>
+              <Text weight='bold'>{account}</Text>
+            </Box>
+            <Box justify='center'>
+              <Button onClick={() => requestPermissions('eth_accounts',{})} primary label="Change" />
+            </Box>
+          </Box>
+          <FormField
+            name="tag"
+            htmlFor="text-input-id-tag"
+            label="Key Tag"
+            validate={[
+              {
+                regexp: /^[A-Za-z0-9-()_]+$/,
+                message: 'Invalid Key tag format'
+              },
+              ((...args: any[]) =>  {
+                const tagExsit = keys.find((key) => key.tag === args[0])
+                if (tagExsit !== undefined) {
+                  return {
+                    message: `Key tag '${tagExsit.tag}' already exists`,
+                    status: 'error'
+                  }
+                }
+              })
+            ]}
+          >
+            <TextInput id="text-input-id-tag" name="tag" />
+          </FormField>
+          <FormField
+            name="note"
+            htmlFor="text-input-id-note"
+            label="Key Note"
+          >
+            <TextInput id="text-input-id-note" name="note" />
+          </FormField>
+          <Box direction="row" gap="medium">
+            <Button size='large' disabled={processing} type="submit" primary label="Add" />
+            <Button size='large' disabled={processing} type='reset' label="Cancel" />
+          </Box>
+          <MessageBox show={error !== undefined} type='error'>
+            <Text size={size}>{error}</Text>
+          </MessageBox>
+        </Form>
+      </Box>
+    </Modal>
+  );
+}

--- a/packages/dapp/src/components/KeysList.tsx
+++ b/packages/dapp/src/components/KeysList.tsx
@@ -1,0 +1,55 @@
+import { Box, Text, Grid, ResponsiveContext } from 'grommet';
+import { useAppState } from "../store";
+import { KeyRecord } from "../store/actions";
+import { Trash, Edit } from 'grommet-icons';
+import { useContext } from 'react';
+
+export const KeysList = () => {
+  const size = useContext(ResponsiveContext);
+  const { account, keys } = useAppState();
+  const status = (key:KeyRecord) => {
+    if (key.revocation !== undefined) {
+      return 'revoked'
+    }
+    if (key.publicKey === account ) {
+      return 'connected'
+    }
+    return ''
+  }
+
+  return (
+    <Box pad='medium'>
+      <Grid
+        pad='small'
+        fill='horizontal'
+        responsive
+        border='bottom'
+        columns={['flex', 'flex', '12rem', 'xsmall', 'xsmall']}
+        align='center'
+      >
+        <Text size={size} weight='bold'>Key note</Text>
+        <Text size={size} weight='bold'>Key tag</Text>
+        <Text size={size} weight='bold'>status</Text>
+        <Text size={size} weight='bold'>Edit</Text>
+        <Text size={size} weight='bold'>Delete</Text>
+      </Grid>
+      {keys.map((key,i) =>
+        <Grid
+          key={i}
+          pad='small'
+          fill='horizontal'
+          responsive
+          border='bottom'
+          columns={['flex', 'flex', '12rem', 'xsmall', 'xsmall']}
+          align='center'
+        >
+          <Text size={size}>{key.note}</Text>
+          <Text size={size}>{key.tag}</Text>
+          <Text size={size}>{status(key)}</Text>
+          <Edit onClick={() => {console.log('Edit')} } />
+          <Trash onClick={() => {console.log('Delete')} }/>
+        </Grid>
+      )}
+    </Box>
+  );
+};

--- a/packages/dapp/src/components/MessageBox.tsx
+++ b/packages/dapp/src/components/MessageBox.tsx
@@ -30,7 +30,6 @@ export const MessageBox = ({
   return (
     <Box
       direction='row'
-      background='light-2'
       align='center'
       gap={size}
       pad={size}

--- a/packages/dapp/src/hooks/useKey.ts
+++ b/packages/dapp/src/hooks/useKey.ts
@@ -1,0 +1,68 @@
+import type { KeyRecord } from '../store/actions';
+import type { JsonRpcSigner } from '@ethersproject/providers';
+import { useState, useMemo, useEffect } from 'react';
+import { findKeyById, findKeyByTag } from './useKeysManager';
+import { useAppState } from '../store';
+import Logger from '../utils/logger';
+
+// Initialize logger
+const logger = Logger('useKeysManager');
+const UNKNOWN_ERROR = 'Unknown useKeysManager error';
+
+export type UseKeyHook = [
+  key: KeyRecord | undefined,
+  signer: JsonRpcSigner | undefined,
+  isConnected: boolean,
+  error: string | undefined,
+];
+
+// UseKey react hook
+export const useKey = (
+  keyIdOrTag: string
+): UseKeyHook => {
+  const { keys, provider, account } = useAppState();
+
+  const [key, setKey] = useState<KeyRecord | undefined>(undefined);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const isConnected = useMemo(
+    () => key !== undefined && key.publicKey === account,
+    [key, account]
+  )
+
+  useEffect(() => {
+    try {
+      let newKey = findKeyById(keys, keyIdOrTag) ?? findKeyByTag(keys, keyIdOrTag)
+      if (newKey === undefined) {
+        throw new Error('Key not found');
+      }
+      setKey(newKey)
+    } catch(error) {
+      logger.error(error);
+      setError((error as Error).message || UNKNOWN_ERROR);
+    }
+  }, [keys, keyIdOrTag])
+
+  const signer = useMemo(() => {
+    try {
+      if (key === undefined) {
+        throw new Error('Key undefined');
+      }
+      if (!isConnected) {
+        throw new Error('Key is not selected');
+      }
+      if (provider === undefined) {
+        throw new Error('Web3 provider undefined');
+      }
+
+      const signer = provider.getSigner(key.publicKey)
+      return signer
+    } catch(error) {
+      logger.error(error);
+      setError((error as Error).message || UNKNOWN_ERROR);
+      return undefined
+    }
+  }, [key, provider]);
+
+  return [key, signer, isConnected, error];
+};

--- a/packages/dapp/src/hooks/useKeysManager.ts
+++ b/packages/dapp/src/hooks/useKeysManager.ts
@@ -26,7 +26,7 @@ export type KeyType =
 export type Keys = KeyRecord[];
 
 export type UseKeysManagerHook = [
-  addKey: (record: KeyRecord) => void,
+  addKey: (record: KeyRecordRaw) => Promise<string | undefined>,
   updateKey: (record: KeyRecord) => void,
   removeKey: (tag: string) => void,
   revokeKey: (tag: string, reason:RevocationReason) => void,
@@ -94,10 +94,11 @@ export const useKeysManager = (): UseKeysManagerHook => {
 
   useEffect(() => {
     setLoading(false);
+    setError(undefined);
   }, [keys])
 
   const addKey = useCallback(
-    (rawRecord: KeyRecordRaw): void => {
+    async (rawRecord: KeyRecordRaw): Promise<string | undefined> => {
       try {
         setLoading(true);
         const record = {
@@ -124,6 +125,7 @@ export const useKeysManager = (): UseKeysManagerHook => {
             record
           }
         });
+        return record.id
       } catch(error) {
         logger.error(error);
         setError((error as Error).message || UNKNOWN_ERROR);

--- a/packages/dapp/src/hooks/useKeysManager.ts
+++ b/packages/dapp/src/hooks/useKeysManager.ts
@@ -78,10 +78,10 @@ const validateKeyWithSchema = (record: KeyRecord): string | null =>
     record
   );
 
-const findKeyById = (keys: KeyRecord[], id: string): KeyRecord | undefined =>
+export const findKeyById = (keys: KeyRecord[], id: string): KeyRecord | undefined =>
   keys.find((key) => key.id === id);
 
-const findKeyByTag = (keys: KeyRecord[], tag: string): KeyRecord | undefined =>
+export const findKeyByTag = (keys: KeyRecord[], tag: string): KeyRecord | undefined =>
   keys.find((key) => key.tag === tag);
 
 // UseKeysManager react hook

--- a/packages/dapp/src/pages/Keys.tsx
+++ b/packages/dapp/src/pages/Keys.tsx
@@ -1,10 +1,19 @@
 import { PageWrapper } from '../pages/PageWrapper';
+import { Box, Button } from 'grommet';
+import { KeyFormModal } from '../components/KeyFormModal';
+import { KeysList } from '../components/KeysList';
+import { useState } from 'react';
 
 export const Keys = () => {
+  const [show, setShow] = useState(false);
 
   return (
     <PageWrapper>
-
+      <KeyFormModal show={show} close={() => setShow(false)} />
+      <Box pad='medium'>
+        <Button size='large' primary label='Add Key' onClick={() => { setShow(true); }} />
+      </Box>
+      <KeysList />
     </PageWrapper>
   );
 };

--- a/packages/dapp/src/store/actions.ts
+++ b/packages/dapp/src/store/actions.ts
@@ -1,4 +1,5 @@
 import type { Web3ModalProvider } from '../hooks/useWeb3Modal';
+import type { KeyType } from '../hooks/useKeysManager';
 import type { IPFS } from '@windingtree/ipfs-apis';
 import type { IProviderInfo } from 'web3modal';
 import type { VerificationMethodReference } from '@windingtree/org.json-schema/types/org.json';


### PR DESCRIPTION
# useKey react hook 

## Affected packages

- @windingtree/org.id-profile-manager

## Description

- Registered keys API must be implemented in the form of React hook `useKey`. This hook must accept a `keyId` or `tag` as an input parameter and returns `[key, signer, error]` as hook parameters:
    - `key` is a dynamic property with a key record
    - `signer` is an `ethers.js` `signer` (can be obtained using provider.getSigner) for a selected key. If key is not currently selected in the Wallet this property must be `undefined`
    - `error` is a dynamic property that refers to internal hook errors, the default value is `undefined`
- Added `<KeyFormModal /> `, `<KeyList />` components  

Task # ([ORGID-100](https://windingtree.atlassian.net/browse/ORGID-100), [ORGID-101](https://windingtree.atlassian.net/browse/ORGID-101))
Fixes # (issue Id)
...

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* required env variable #1
* required env variable #2

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
