### PR TITLE
feat(org.id-profile-manager): proper logout flow

### DIFF
--- a/packages/dapp/src/components/AppHeader.tsx
+++ b/packages/dapp/src/components/AppHeader.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { Image, Header, Heading, Box, ResponsiveContext } from 'grommet';
 import { useAppState } from '../store';
 import { Account } from '../components/Account';
-import { SignInButton, SignOutButton } from '../components/buttons/web3Modal';
+import { SignInButton, LogoutButton } from '../components/buttons/web3Modal';
 import { SwitchThemeMode } from './SwitchThemeMode';
 import { GlobalMenu, usePageTitle } from './Routes';
 
@@ -38,7 +38,7 @@ export const AppHeader = () => {
         <Account account={account} />
         <Box>
           {account
-            ? <SignOutButton />
+            ? <LogoutButton />
             : <SignInButton />
           }
         </Box>

--- a/packages/dapp/src/components/buttons/web3Modal.tsx
+++ b/packages/dapp/src/components/buttons/web3Modal.tsx
@@ -34,20 +34,20 @@ export const SignInButton = () => {
   )
 };
 
-export const SignOutButton = () => {
+export const LogoutButton = () => {
   const size = useContext(ResponsiveContext);
-  const { isConnecting, signOut } = useAppState();
+  const { isConnecting, logout } = useAppState();
 
   return (
     <Button
-      onClick={() => signOut()}
+      onClick={() => logout()}
       disabled={isConnecting}
     >
       {() => (
         <Box direction='row' align='center' pad='small'>
           {size !== 'small' &&
             <Text>
-              {isConnecting ? 'Connecting' : 'Disconnect'}
+              {isConnecting ? 'Connecting' : 'Logout'}
             </Text>
           }
           {size === 'small' &&

--- a/packages/dapp/src/store/actions.ts
+++ b/packages/dapp/src/store/actions.ts
@@ -42,7 +42,7 @@ export interface State {
   injectedProvider?: IProviderInfo;
   account?: string;
   signIn: Function;
-  signOut: Function;
+  logout: Function;
   errors: string[];
   themeMode: ThemeMode;
   ipfsNode?: IPFS;
@@ -88,7 +88,7 @@ export interface SetWeb3modalFunctionsAction {
   type: 'SET_WEB3MODAL_FUNCTIONS',
   payload: {
     signIn: Function;
-    signOut: Function;
+    logout: Function;
   }
 }
 

--- a/packages/dapp/src/store/index.tsx
+++ b/packages/dapp/src/store/index.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react';
 import type { Web3ModalConfig } from '../hooks/useWeb3Modal';
 import { createContext, useContext, useEffect } from 'react';
 import WalletConnectProvider from '@walletconnect/web3-provider';
-// import Logger from '../utils/logger';
 import { useAppReducer } from './reducer';
+import { assertNonNullish } from '../utils/types';
 
 // Custom hooks
 import { useWeb3Modal } from '../hooks/useWeb3Modal';
@@ -16,9 +16,6 @@ import {
   getNetworksIds,
   getNetworksRpcs
 } from '../config';
-
-// Initialize logger
-// const logger = Logger('Store');
 
 export type AppReducerType = ReturnType<typeof useAppReducer>;
 export type State = AppReducerType[0];
@@ -33,20 +30,14 @@ export interface PropsType {
 
 export const useAppState = () => {
   const ctx = useContext(StateContext);
-
-  if (!ctx) {
-    throw new Error('Missing state context');
-  }
+  assertNonNullish(ctx, 'Missing state context');
 
   return ctx;
 };
 
 export const useAppDispatch = () => {
   const ctx = useContext(DispatchContext);
-
-  if (!ctx) {
-    throw new Error('Missing dispatch context');
-  }
+  assertNonNullish(ctx, 'Missing dispatch context');
 
   return ctx;
 }
@@ -74,7 +65,7 @@ export const AppStateProvider = ({ children }: PropsType) => {
     injectedProvider,
     isConnecting,
     signIn,
-    signOut,
+    logout,
     web3ModalError
   ] = useWeb3Modal(web3ModalConfig);
   const [
@@ -167,10 +158,10 @@ export const AppStateProvider = ({ children }: PropsType) => {
       type: 'SET_WEB3MODAL_FUNCTIONS',
       payload: {
         signIn,
-        signOut
+        logout
       }
     })
-  }, [dispatch, signIn, signOut]);
+  }, [dispatch, signIn, logout]);
 
   useEffect(() => {
     dispatch({

--- a/packages/dapp/src/store/reducer.ts
+++ b/packages/dapp/src/store/reducer.ts
@@ -54,7 +54,7 @@ export const mainReducer = (state: State, action: Action): State => {
         return {
           ...state,
           signIn: action.payload.signIn,
-          signOut: action.payload.signOut
+          logout: action.payload.logout
         };
       case 'SET_IPFS_NODE_CONNECTING':
         return {
@@ -145,7 +145,7 @@ const initialState: State = {
   isRightNetwork: true,
   isIpfsNodeConnecting: false,
   signIn: () => {},
-  signOut: () => {},
+  logout: () => {},
   errors: [],
   themeMode:ThemeMode.light,
   startIpfsNode: () => {},

--- a/packages/dapp/src/utils/types.ts
+++ b/packages/dapp/src/utils/types.ts
@@ -1,0 +1,9 @@
+function assertNonNullish<TValue>(value: TValue, message: string): asserts value is NonNullable<TValue> {
+  if (value === null || value === undefined) {
+    throw Error(message);
+  }
+}
+
+export {
+  assertNonNullish,
+};


### PR DESCRIPTION
# Pull Request Template

## Affected packages

- @windingtree/org.id-profile-manager

## Description

There should be a `logout` button. When clicked, final snapshot of data is stored in local storage (encrypted), and storage is cleared. App is redirected to `/`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
